### PR TITLE
Wickford 2023, Fall Dinghy 2022, Carl Miller 2021

### DIFF
--- a/data/results/2021/country/usa/2021-10-31.carl-miller-regatta.galesville-md.USA.csv
+++ b/data/results/2021/country/usa/2021-10-31.carl-miller-regatta.galesville-md.USA.csv
@@ -5,7 +5,7 @@ USA,9160,Howard Hamlin,,ABYC / NHYC,2,4,2,[6],3,1,4,1,5,2,,24,3
 USA,8714,Mike Zani,,Common Fence Point Dinghy Club,[4],3,1,3,4,2,3,4,1,4,,25,4
 USA,9172,Paul Scoffin,,MBYC,8,5,7,4,7,7,5,5,4,[20/DNS],Tamaki,52,5
 USA,9095,G Nelson,,West River,5,8,3,5,5,[10],8,8,8,6,Highway 95 Revisited,56,6
-USA,8951,David Kirkpatrick,,David Kirkpatrick,7,7,9,7,6,5,10,10,6,[11],Toxic Masculinity,67T,7
+USA,8951,David Kirkpatrick,Adam Wolnikowski,David Kirkpatrick,7,7,9,7,6,5,10,10,6,[11],Toxic Masculinity,67T,7
 USA,8930,Duane Delfosse,,Lsyc,9,6,8,9,9,[11],7,7,7,5,,67T,8
 USA,8937,Tim Murphy,,None,6,[11],5,10,11,9,6,6,10,8,,71,9
 USA,8883,Ben Komar,,WRSC,[20/DNF],12,13,20/DNF,8,8,11,11,9,7,Jane's Addiction,99,10

--- a/data/results/2022/country/usa/2022-10-23.fall-dinghy.san-francisco.USA.csv
+++ b/data/results/2022/country/usa/2022-10-23.fall-dinghy.san-francisco.USA.csv
@@ -6,7 +6,7 @@ USA,8939,Clark Hayes,Eric Schwab,Corinthian Yacht Club of Seattle,2,7,2,[8],4,Co
 USA,8714,Reeve Dunne,Ted Conrads,N/A,[6],4,6,2,5,None,17,23,5
 USA,8931,Elsa Balton,Ben Kaas,CBC,4,6,8,6,[10],Vikings C,24,34,6
 USA,8829,Lena Captain,Miles Johannessen,Seattle Yacht Club,5,8,5,7,[11],Viking A,25,36,7
-USA,9082,Jeff Miller,Adam Wolnikovsky,Santa Cruz YC,7,[10],4,9,6,Miracle,26,36,8
+USA,9082,Jeff Miller,Adam Wolnikowski,Santa Cruz YC,7,[10],4,9,6,Miracle,26,36,8
 USA,8937,Tim Murphy,Brendan Heussler,None,9,5,[10],5,8,None,27,37,9
 USA,9083,Aaron Ross,Rob Waterman,Santa Cruz Yacht Club,8,[9],9,4,7,Cosmic Thing,28,37,10
 USA,9073,Jazzy Gerraty,Colin Wahl,None ,10,11,11,[DNC - 16],9,Vikings B,41,57,11

--- a/data/results/2023/country/usa/2023-06-04.wickford-regatta.north-kingstown-ri.USA.csv
+++ b/data/results/2023/country/usa/2023-06-04.wickford-regatta.north-kingstown-ri.USA.csv
@@ -1,15 +1,15 @@
-Country,Sail,Skipper,,,Race 1,Race 2,Race 3,Race 4,Race 5,Race 6,Race 7,,Total,Pos
-USA,8854,Craig Thompson,,,1,1,1,3,1,1,[4],,8,1
-USA,8951,David Kirkpatrick,Keith Longson,,2,[4],4,1,3,3,3,,16,2
-USA,8851,William Huebner,Ethan Bixby,,3,8,[9],5,4,7,1,,28T,3
-USA,8786,Luke Ingalls,,,[7],5,3,6,2,6,6,,28T,4
-USA,8930,Duane Delfosse,,,6,9,5,4,[15/RET],2,7,,33,5
-USA,8808,Ted Bjerregaard,Matt Hersey,,8,6,7,8,6,[15/DNF],2,,37,6
-USA,9095,Macy Nelson,,,5,3,6,7,5,[15/RET],15/RET,,41,7
-USA,8715,Paul Taylor,,,9,10,10,2,8,4,[15/RET],,43,8
-USA,9003,Art Gleason,Jonathan Gleason,,[11],11,11,10,7,5,5,,49T,9
-IRL,8987,Peter Scannell,,,[16/DNS],7,8,9,9,8,8,,49T,10
-USA,9005,Thomas Kivney,,,4,2,2,[15/RET],15/RET,15/DNS,15/DNS,,53,11
-USA,7359,Robert Long,Clay Greig,,10,13,12,11,10,9,[15/DNS],,65,12
-USA,8952,Will Platt,,,[16/DNS],15/DNS,15/DNS,15/DNS,15/DNS,15/DNS,9,,84,13
-USA,8952,Michael Breton,TJ Obrien,,[16/DNF],12,15/RET,15/RET,15/RET,15/RET,15/RET,,87,14
+Country,Sail,Skipper,,,Race 1,Race 2,Race 3,Race 4,Race 5,Race 6,Race 7,Race 8,,Total,Pos
+USA,8854,Craig Thompson,Adam Wolnikowski,,1,1,1,3,1,1,[4],1,,9,1
+USA,8951,David Kirkpatrick,Keith Longson,,2,4,4,1,3,3,3,[6],,20,2
+USA,8786,Luke Ingalls,John Ingalls,,[7],5,3,6,2,6,6,2,,30,3
+USA,8851,William Huebner,Ethan Bixby,,3,8,[9],5,4,7,1,4,,32,4
+USA,8930,Duane Delfosse,Mike Hull,,6,9,5,4,[15/RET],2,7,5,,38,5
+USA,8808,Ted Bjerregaard,Matt Hersey,,8,6,7,8,6,[15/DNF],2,8,,45,6
+USA,9003,Art Gleason,Jonathan Gleason,,[11],11,11,10,7,5,5,3,,52,7
+USA,9095,Macy Nelson,Nate Barton,,5,3,6,7,5,[15/RET],15/RET,15/RET,,56T,8
+IRL,8987,Peter Scannell,John Dunleg,,[16/DNS],7,8,9,9,8,8,7,,56T,9
+USA,8715,Paul Taylor,Sol Marini,,9,10,10,2,8,4,[15/RET],15/RET,,58,10
+USA,9005,Thomas Kivney,Gordon Russel,,4,2,2,[15/RET],15/RET,15/DNS,15/DNS,15/DNS,,68,11
+USA,7359,Robert Long,Clay Greig,,10,13,12,11,10,9,[15/DNS],15/DNF,,80,12
+USA,8952,Will Platt,William R Platt,,[16/DNS],15/DNS,15/DNS,15/DNS,15/DNS,15/DNS,9,15/DNS,,99,13
+USA,8952,Michael Breton,TJ Obrien,,[16/DNF],12,15/RET,15/RET,15/RET,15/RET,15/RET,15/DNF,,102,14


### PR DESCRIPTION
Uzupełniłem wyniki z Wickford 2023

https://www.regattanetwork.com/clubmgmt/applet_regatta_results.php?regatta_id=25596&show_crew=1&limit_fleet=505

Poprawiłem nazwisko swoje w wynikach Fall Dinghy 2022 i Carl Miller 2021